### PR TITLE
Refactor the crypt package to support FIPS encryption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 coverage.out
 coverage.html
+coverage-fips.out
+coverage-fips.html
 rskey
 dist/

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ check: fmt vet
 test:
 	GO111MODULE=on go test ./... $(GO_BUILD_ARGS) -coverprofile coverage.out
 	go tool cover -html=coverage.out -o coverage.html
+	GO111MODULE=on go test ./... $(GO_BUILD_ARGS) -tags "fips" -coverprofile coverage-fips.out
+	go tool cover -html=coverage-fips.out -o coverage-fips.html
 
 .PHONY: fmt
 fmt:

--- a/crypt/aes.go
+++ b/crypt/aes.go
@@ -1,0 +1,73 @@
+// Copyright 2022 RStudio, PBC
+// SPDX-License-Identifier: Apache-2.0
+
+package crypt
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+)
+
+const (
+	// The AEAD.Overhead() here is 16, plus 12 for the nonce, plus 1 for the
+	// version.
+	minimumAESLength = 16 + 12 + 1
+)
+
+// EncryptFIPS produces base64-encoded cipher text for the given payload and key
+// using a FIPS-compatible algorithm, or an error if one cannot be created.
+func (k *Key) EncryptFIPS(s string) (string, error) {
+	return k.EncryptBytesFIPS([]byte(s))
+}
+
+// EncryptBytesFIPS produces base64-encoded cipher text for the given bytes and
+// key using a FIPS-compatible algorithm, or an error if one cannot be created.
+func (k *Key) EncryptBytesFIPS(bytes []byte) (string, error) {
+	output, err := k.encryptAES(bytes)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(output), nil
+}
+
+func (k *Key) encryptAES(bytes []byte) ([]byte, error) {
+	nonce := make([]byte, 12)
+	_, err := rand.Read(nonce)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	aead := k.newAESGCM()
+	output := aead.Seal(nil, nonce, bytes, nil)
+	output = append(nonce, output...)
+	// Append a version prefix.
+	output = append([]byte{2}, output...)
+	return output, nil
+}
+
+func (k *Key) decryptAES(buf []byte) ([]byte, error) {
+	if len(buf) < minimumAESLength {
+		return []byte{}, ErrPayLoadTooShort
+	}
+
+	// Note: We're skipping the version prefix here.
+	nonce := make([]byte, 12)
+	copy(nonce, buf[1:13])
+
+	aead := k.newAESGCM()
+	bytes, err := aead.Open(nil, nonce, buf[13:], nil)
+	if err != nil {
+		return []byte{}, ErrFailedToDecrypt
+	}
+	return bytes, nil
+}
+
+func (k *Key) newAESGCM() cipher.AEAD {
+	// The only way either of these can error is by having an incorrect byte
+	// slice length or algorithm.
+	block, _ := aes.NewCipher(k[0:32])
+	aead, _ := cipher.NewGCM(block)
+	return aead
+}

--- a/crypt/fips.go
+++ b/crypt/fips.go
@@ -1,0 +1,20 @@
+// Copyright 2022 RStudio, PBC
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build fips
+// +build fips
+
+package crypt
+
+// When true, this package has been built in "FIPS mode". Attempts to use
+// encryption algorithms not permissible under FIPS-140 regulations will always
+// fail, and encryption will use AES-256-GCM by default.
+const FIPSMode = true
+
+func (k *Key) encryptSecretbox(bytes []byte) ([]byte, error) {
+	return []byte{}, ErrFIPS
+}
+
+func (k *Key) decryptSecretbox(buf []byte) ([]byte, error) {
+	return []byte{}, ErrFIPS
+}

--- a/crypt/fips_test.go
+++ b/crypt/fips_test.go
@@ -1,0 +1,13 @@
+// Copyright 2022 RStudio, PBC
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build fips
+// +build fips
+
+package crypt
+
+import "gopkg.in/check.v1"
+
+func (s *KeySuite) TestFIPSMode(c *check.C) {
+	c.Check(FIPSMode, check.Equals, true)
+}

--- a/crypt/nacl.go
+++ b/crypt/nacl.go
@@ -1,6 +1,9 @@
 // Copyright 2022 RStudio, PBC
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !fips
+// +build !fips
+
 package crypt
 
 import (
@@ -8,6 +11,11 @@ import (
 
 	"golang.org/x/crypto/nacl/secretbox"
 )
+
+// When true, this package has been built in "FIPS mode". Attempts to use
+// encryption algorithms not permissible under FIPS-140 regulations will always
+// fail, and encryption will use AES-256-GCM by default.
+const FIPSMode = false
 
 const (
 	// The overhead length plus the nonce length.

--- a/crypt/nacl_test.go
+++ b/crypt/nacl_test.go
@@ -1,0 +1,13 @@
+// Copyright 2022 RStudio, PBC
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !fips
+// +build !fips
+
+package crypt
+
+import "gopkg.in/check.v1"
+
+func (s *KeySuite) TestFIPSMode(c *check.C) {
+	c.Check(FIPSMode, check.Equals, false)
+}


### PR DESCRIPTION
This is with the aim of providing a FIPS-140 compliant version of this package and related tools: #2.

The existing NaCl secretbox algorithm is not a FIPS-140 approved algorithm, so this commit adds a second AES-256-GCM option, which is.

Users can make an explicit runtime decision to use the FIPS algorithm through the new `EncryptFIPS()` method. The existing `Decrypt()` method has been taught to recognise ciphertext encrypted this way using the version prefix machinery.

In addition, the package can now be built with a 'fips' tag. When this occurs, we swap out the NaCl algorithm for AES-256-GCM in `Encrypt()` and all attempts to call the NaCl algorithm will result in a new error, `ErrFIPS`.

Since software essentially expects to be FIPS-compliant or not (there is no gray zone), a compile-time setting seems like the most coherent choice for users who are expected to operate in these environments. I've found a few other examples of this pattern [in the Go ecosystem](https://github.com/elastic/harp/).

The crypt API now includes a global constant indicates whether the package was built in "FIPS mode", and there are also some new tests for this constant that effectively verify the build tags.

**Important Caveat**

This change alone *cannot* produce a FIPS-compliant binary, because Go's `crypto` packages *are not FIPS-compilant*.

One must also build using the `dev.boringcrypto` Go toolchain, which swaps out the `crypto` package for one backed by BoringSSL -- itself a validated library. This is an emerging best practice for Go tools that want to be FIPS-compliant.