### PR TITLE
Add decrypt prompt

### DIFF
--- a/cmd/decrypt.go
+++ b/cmd/decrypt.go
@@ -55,7 +55,10 @@ func runDecrypt(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "%s\n", cipher)
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", cipher)
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	}
@@ -79,8 +82,8 @@ func runDecrypt(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "%s\n", cipher)
-	return nil
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", cipher)
+	return err
 }
 
 func init() {

--- a/cmd/encrypt.go
+++ b/cmd/encrypt.go
@@ -54,7 +54,10 @@ func runEncrypt(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "%s\n", cipher)
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", cipher)
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	}
@@ -76,8 +79,8 @@ func runEncrypt(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "%s\n", cipher)
-	return nil
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", cipher)
+	return err
 }
 
 func init() {

--- a/cmd/encrypt.go
+++ b/cmd/encrypt.go
@@ -67,8 +67,11 @@ func runEncrypt(cmd *cobra.Command, args []string) error {
 		}
 		defer term.Restore(int(os.Stdin.Fd()), s)
 		return term.NewTerminal(os.Stdin, "").ReadPassword(
-			"Enter the sensitive data to encrypt, then Enter: ")
+			"Type the sensitive data to encrypt, then press Enter: ")
 	}()
+	if err != nil {
+		return err
+	}
 	cipher, err := key.Encrypt(data)
 	if err != nil {
 		return err


### PR DESCRIPTION
We implemented a prompt for encryption when no data is provided on `stdin`, however, we never implemented the same for the `decrypt` function.

In this PR:
- add a prompt for the decrypt function, following the same pattern
- address an uncaught error for the lambda function during encryption
- address uncaught errors for Fprintf that the IDE was complaining about.