### PR TITLE
Add the "Go BoringCrypto" toolchain for CI and releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: ci
 on:
   push:
+    branches:
+    - main
   pull_request:
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,26 @@ jobs:
       run: make check
     - name: Check Licenses
       run: make check-license
+    - uses: actions/cache@v3
+      id: goboring-cache
+      with:
+        path: /opt/goboring/
+        key: ${{ runner.os }}-goboring-${{ hashFiles('/opt/goboring/go/VERSION') }}
+        restore-keys: |
+          ${{ runner.os }}-goboring-
+    - name: Set up GoBoring
+      if: steps.goboring-cache.outputs.cache-hit != 'true'
+      run: |
+        mkdir -p /opt/goboring
+        cd /opt/goboring
+        wget --no-verbose https://go-boringcrypto.storage.googleapis.com/go1.18b7.linux-amd64.tar.gz
+        tar -xzvf go1.18b7.linux-amd64.tar.gz
+        /opt/goboring/go/bin/go version
+    - name: Build
+      run: make GOBIN=/opt/goboring/go/bin/go CGO_ENABLED=1 GO_BUILD_ARGS='-v -tags "netgo fips" -trimpath' GO_LDFLAGS='-s -w -linkmode=external -extldflags=-static' static-build
+      env:
+        GOROOT: /opt/goboring/go
+    - name: Test
+      run: make GOBIN=/opt/goboring/go/bin/go CGO_ENABLED=1 GO_BUILD_ARGS='-v -tags "netgo fips" -trimpath' GO_LDFLAGS='-s -w -linkmode=external -extldflags=-static' test
+      env:
+        GOROOT: /opt/goboring/go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
     - '*'
+  pull_request:
 permissions:
   contents: write
   id-token: write
@@ -49,7 +50,10 @@ jobs:
       with:
         distribution: goreleaser
         version: latest
-        args: release --rm-dist
+        args: release --rm-dist --snapshot --skip-sign
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COSIGN_EXPERIMENTAL: 1
+    - run: |
+        aws sts get-caller-identity
+        aws s3 cp dist s3://rstudio-platform-public-artifacts/rskey/devel/ --recursive --exclude "*" --include "*.tar.gz"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,21 @@ jobs:
       uses: sigstore/cosign-installer@main
       with:
         cosign-release: 'v1.6.0'
+    - uses: actions/cache@v3
+      id: goboring-cache
+      with:
+        path: /opt/goboring/
+        key: ${{ runner.os }}-goboring-${{ hashFiles('/opt/goboring/go/VERSION') }}
+        restore-keys: |
+          ${{ runner.os }}-goboring-
+    - name: Set up GoBoring
+      if: steps.goboring-cache.outputs.cache-hit != 'true'
+      run: |
+        mkdir -p /opt/goboring
+        cd /opt/goboring
+        wget --no-verbose https://go-boringcrypto.storage.googleapis.com/go1.18b7.linux-amd64.tar.gz
+        tar -xzvf go1.18b7.linux-amd64.tar.gz
+        /opt/goboring/go/bin/go version
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ jobs:
       uses: sigstore/cosign-installer@main
       with:
         cosign-release: 'v1.6.0'
+    - uses: aws-actions/configure-aws-credentials@v1
+      with:
+        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+        role-session-name: gha-rskey
+        aws-region: us-east-1
     - uses: actions/cache@v3
       id: goboring-cache
       with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -47,6 +47,10 @@ archives:
   - README.md
   - NOTICE.md
   name_template: "{{ .ProjectName }}-fips_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+blobs:
+- provider: s3
+  bucket: rstudio-platform-public-artifacts
+  folder: "rskey/{{ .Version }}"
 release:
   draft: true
 signs:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,11 +16,37 @@ builds:
   mod_timestamp: '{{ .CommitTimestamp }}'
   tags:
   - netgo
+- id: fips
+  binary: rskey-fips
+  env:
+  - CGO_ENABLED=1
+  - GOROOT=/opt/goboring/go
+  flags:
+  - -trimpath
+  gobinary: /opt/goboring/go/bin/go
+  ldflags:
+  - -s -w -linkmode=external -extldflags=-static
+  mod_timestamp: "{{ .CommitTimestamp }}"
+  tags:
+  - fips
+  - netgo
+  targets:
+  - linux_amd64
 archives:
-- files:
+- builds:
+  - rskey
+  files:
   - LICENSE
   - README.md
   - NOTICE.md
+- id: fips
+  builds:
+  - fips
+  files:
+  - LICENSE
+  - README.md
+  - NOTICE.md
+  name_template: "{{ .ProjectName }}-fips_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 release:
   draft: true
 signs:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,7 +16,10 @@ builds:
   mod_timestamp: '{{ .CommitTimestamp }}'
   tags:
   - netgo
+  targets:
+  - linux_amd64
 - id: fips
+  skip: true
   binary: rskey-fips
   env:
   - CGO_ENABLED=1

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+GOBIN = go
 CGO_ENABLED = 0
 # Strip binaries by default to make them smaller.
 GO_LDFLAGS = -s -w
@@ -5,7 +6,7 @@ GO_LDFLAGS = -s -w
 # static binaries.
 GO_BUILD_ARGS = -v -tags "netgo" -trimpath
 
-GOPATH = `go env GOPATH`
+GOPATH = `$(GOBIN) env GOPATH`
 ADDLICENSE = $(GOPATH)/bin/addlicense
 ADDLICENSE_ARGS = -v -s=only -l=apache -c "RStudio, PBC" -ignore 'coverage*' -ignore '.github/**' -ignore '.goreleaser.yaml'
 NOTICETOOL = $(GOPATH)/bin/go-licence-detector
@@ -14,7 +15,7 @@ all: rskey
 
 .PHONY: rskey
 rskey:
-	GO111MODULE=on CGO_ENABLED=$(CGO_ENABLED) go build \
+	GO111MODULE=on CGO_ENABLED=$(CGO_ENABLED) $(GOBIN) build \
 		-ldflags="$(GO_LDFLAGS)" $(GO_BUILD_ARGS) -o $@ ./$<
 
 .PHONY: static-build
@@ -25,18 +26,18 @@ check: fmt vet
 
 .PHONY: test
 test:
-	GO111MODULE=on go test ./... $(GO_BUILD_ARGS) -coverprofile coverage.out
-	go tool cover -html=coverage.out -o coverage.html
-	GO111MODULE=on go test ./... $(GO_BUILD_ARGS) -tags "fips" -coverprofile coverage-fips.out
-	go tool cover -html=coverage-fips.out -o coverage-fips.html
+	GO111MODULE=on $(GOBIN) test ./... $(GO_BUILD_ARGS) -coverprofile coverage.out
+	$(GOBIN) tool cover -html=coverage.out -o coverage.html
+	GO111MODULE=on $(GOBIN) test ./... $(GO_BUILD_ARGS) -tags "fips" -coverprofile coverage-fips.out
+	$(GOBIN) tool cover -html=coverage-fips.out -o coverage-fips.html
 
 .PHONY: fmt
 fmt:
-	GO111MODULE=on go fmt ./...
+	GO111MODULE=on $(GOBIN) fmt ./...
 
 .PHONY: vet
 vet:
-	GO111MODULE=on go vet ./...
+	GO111MODULE=on $(GOBIN) vet ./...
 
 .PHONY: check-license
 check-license:


### PR DESCRIPTION
This PR adds a second Go toolchain to the GitHub Actions environments used for builds, tests, and releases, as well as the
related changes to GoReleaser's configuration. This was proposed in #2.

This "BoringCrypto" [fork of Go's toolchain](https://go.googlesource.com/go/+/dev.boringcrypto/README.boringcrypto.md) is maintained by the Go team, and has become the de-facto way to provide FIPS-validated crypto for software written in Go. Binary releases are only available for Linux, so that is the only platform we can support ourselves for now.

With this change, releases will have a new "rskey-fips" archive for the `linux_amd64` target. This version of rskey will refuse to use cryptographic algorithms that are not FIPS approved, and may be broken in unexpected ways -- some caution is warranted. However, for customers that are in theory bound by FIPS-140, this may be a very appealing distribution of the tool.

This PR does not include documentation for these new release binaries because no release yet includes them.

[0]: https://go.googlesource.com/go/+/dev.boringcrypto/README.boringcrypto.md