### PR TITLE
Publish release artifacts to S3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ jobs:
       uses: sigstore/cosign-installer@main
       with:
         cosign-release: 'v1.6.0'
+    - uses: aws-actions/configure-aws-credentials@v1
+      with:
+        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+        role-session-name: gha-rskey
+        aws-region: us-east-1
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,6 +24,10 @@ archives:
   format_overrides:
   - goos: windows
     format: zip
+blobs:
+- provider: s3
+  bucket: rstudio-platform-public-artifacts
+  folder: "rskey/{{ .Version }}"
 release:
   draft: true
   header: |


### PR DESCRIPTION
This uses GitHub Action's federated OIDC support, so it does not require any explicit credentials.

The role ARN is stored in a GitHub secret to avoid leaking our account ID, but it's not sensitive data otherwise.