### PR TITLE
Embed version string from git description

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,7 +12,7 @@ builds:
   - windows
   - darwin
   ldflags:
-  - -s -w
+  - -s -w -X github.com/rstudio/rskey/cmd.Version={{ .Version }}
   mod_timestamp: '{{ .CommitTimestamp }}'
   tags:
   - netgo

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
+VERSION := $(shell git describe --always --dirty --tags)
+
 CGO_ENABLED = 0
 # Strip binaries by default to make them smaller.
-GO_LDFLAGS = -s -w
+GO_LDFLAGS = -s -w -X github.com/rstudio/rskey/cmd.Version=$(VERSION)
 # Using the 'netgo' tag opts into the native implementation and allows for
 # static binaries.
 GO_BUILD_ARGS = -v -tags "netgo" -trimpath
 
-GOPATH = `go env GOPATH`
+GOPATH = $(shell go env GOPATH)
 ADDLICENSE = $(GOPATH)/bin/addlicense
 ADDLICENSE_ARGS = -v -s=only -l=apache -c "RStudio, PBC" -ignore 'coverage*' -ignore '.github/**' -ignore '.goreleaser.yaml'
 NOTICETOOL = $(GOPATH)/bin/go-licence-detector

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,9 +9,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	Version = "???"
+)
+
 var rootCmd = &cobra.Command{
-	Use:   "rskey",
-	Short: "Manage keys and secrets for RStudio Connect and Package Manager",
+	Use:     "rskey",
+	Short:   "Manage keys and secrets for RStudio Connect and Package Manager",
+	Version: Version,
 }
 
 // Execute runs the rskey command. On error it will call os.Exit.


### PR DESCRIPTION
so that `rskey --version` may be used to confirm the desired version is installed.