### PR TITLE
Fix Fprintf call with no format string

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -33,7 +33,7 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 	s := key.HexString()
 	outfile := cmd.Flag("output").Value.String()
 	if outfile == "" {
-		fmt.Fprintf(cmd.OutOrStdout(), s)
+		fmt.Fprint(cmd.OutOrStdout(), s)
 		return nil
 	}
 	err = os.WriteFile(outfile, []byte(s), 0600)


### PR DESCRIPTION
This causes a compiler error under Go 1.24 that was previously ignored:

> cmd/generate.go:36:34: non-constant format string in call to fmt.Fprintf

This commit switches to `fmt.Fprint()`, which is probably what was originally intended.