### PR TITLE
Avoid building releases for 32-bit platforms

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,6 +11,9 @@ builds:
   - linux
   - windows
   - darwin
+  goarch:
+  - amd64
+  - arm64
   ldflags:
   - -s -w -X github.com/rstudio/rskey/cmd.Version={{ .Version }}
   mod_timestamp: '{{ .CommitTimestamp }}'


### PR DESCRIPTION
These are firmly outside of our supported platform list and virtually unheard of among customers.