### PR TITLE
Update docs and release pipeline: COSIGN_EXPERIMENTAL is no longer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,4 +34,3 @@ jobs:
         args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        COSIGN_EXPERIMENTAL: 1

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,12 +41,12 @@ release:
     Binary releases are signed with [Sigstore](https://www.sigstore.dev/). You can verify these signatures with their `cosign` tool, for example:
 
     ``` shell
-    $ COSIGN_EXPERIMENTAL=1 cosign verify-blob \
+    $ cosign verify-blob \
       --signature rskey_{{ .Version }}_linux_amd64.tar.gz.sig \
       rskey_{{ .Version }}_linux_amd64.tar.gz
     ```
 
-    We use Cosign's ["keyless"](https://docs.sigstore.dev/cosign/openid_signing) mode, which uses the OpenID Connect tokens issued by GitHub for this repository and ephemeral certificates instead of private keys. This feature currently requires setting `COSIGN_EXPERIMENTAL=1`.
+    We use Cosign's ["keyless"](https://docs.sigstore.dev/cosign/signing/overview/) mode, which uses the OpenID Connect tokens issued by GitHub for this repository and ephemeral certificates instead of private keys.
 signs:
 - cmd: cosign
   signature: "${artifact}.sig"

--- a/README.md
+++ b/README.md
@@ -38,15 +38,14 @@ Binary releases are signed with [Sigstore](https://www.sigstore.dev/). You can
 verify these signatures with their `cosign` tool, for example:
 
 ``` shell
-$ COSIGN_EXPERIMENTAL=1 cosign verify-blob \
+$ cosign verify-blob \
   --signature rskey_0.5.0_linux_amd64.tar.gz.sig \
   rskey_0.5.0_linux_amd64.tar.gz
 ```
 
-We use Cosign's ["keyless"](https://docs.sigstore.dev/cosign/openid_signing)
+We use Cosign's ["keyless"](https://docs.sigstore.dev/cosign/signing/overview/)
 mode, which uses the OpenID Connect tokens issued by GitHub for this repository
-and ephemeral certificates instead of private keys. This feature currently
-requires setting `COSIGN_EXPERIMENTAL=1`.
+and ephemeral certificates instead of private keys.
 
 ## Usage
 


### PR DESCRIPTION
As expected, this feature is now stable and the default way to use Sigstore.