### PR TITLE
Start building .deb and .rpm packages for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,9 @@ jobs:
       run: make check
     - name: Check Licenses
       run: make check-license
+    - name: GoReleaser Dry-run
+      uses: goreleaser/goreleaser-action@v5
+      with:
+        distribution: goreleaser
+        version: v2
+        args: release --snapshot --skip=before,sign

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -56,3 +56,22 @@ signs:
   artifacts: all
 source:
   enabled: true
+nfpms:
+- id: rskey
+  builds:
+  - rskey
+  formats:
+  - deb
+  - rpm
+  section: devel
+  maintainer: "Posit Software, PBC <info@posit.co>"
+  description: |
+    A command-line tool that generates secret keys interoperable with the format
+    used by Posit's Workbench, Connect, and Package Manager products.
+  contents:
+  - src: LICENSE
+    dst: /usr/share/doc/rskey/LICENSE
+  - src: README.md
+    dst: /usr/share/doc/rskey/README.md
+  - src: NOTICE.md
+    dst: /usr/share/doc/rskey/NOTICE.md


### PR DESCRIPTION
In order to confirm that these actually build, CI now runs GoReleaser, too.

Closes #21.